### PR TITLE
feat: add Oxylabs proxy support for Vercel deployments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,28 @@ Binance Portfolio Monitor tracks cryptocurrency trading performance against a 50
 
 ## Recent Updates
 
+### Oxylabs Proxy Integration for Vercel (2025-07-13)
+- **Critical Issue Resolved**: Bypassed Binance geographic restrictions on Vercel using Oxylabs proxy
+- **Problem**: Binance blocks all cloud provider IPs (AWS, GCP, Vercel) even in Frankfurt region
+- **Previous Workarounds**: Data API works for prices, but private endpoints (NAV, balances) were still blocked
+- **Solution**: Implemented conditional proxy usage only for Vercel deployments
+- **Implementation Details**:
+  - Added proxy configuration to `config/settings.json` with environment-based activation
+  - Created `create_binance_client()` wrapper function with proxy support
+  - Proxy applies only to authenticated API calls (NAV, balances, transactions)
+  - Price fetching continues using data-api.binance.vision (no proxy needed)
+  - Dashboard remains proxy-independent (reads from database only)
+- **Security**: 
+  - Proxy credentials stored in `OXYLABS_PROXY_URL` environment variable
+  - No hardcoded credentials in code
+  - Proxy active only when: `VERCEL` env detected + `OXYLABS_PROXY_URL` configured
+- **Files Modified**: 
+  - `config/settings.json` - Added proxy configuration section
+  - `config/__init__.py` - Added ProxyConfig dataclass with smart activation
+  - `api/index.py` - Implemented create_binance_client() with conditional proxy
+- **Testing**: Local development unaffected (no proxy), Vercel uses proxy automatically
+- **Documentation**: See `PROXY_SETUP.md` for detailed setup instructions
+
 ### Vercel Cron Job Fix - Data API URL Persistence (2025-07-12)
 - **Critical Issue Resolved**: Fixed hourly cron job failures on Vercel due to API URL restoration
 - **Problem**: `get_prices()` was restoring original API URL after fetching prices, causing subsequent calls to fail

--- a/PROXY_SETUP.md
+++ b/PROXY_SETUP.md
@@ -1,0 +1,187 @@
+# Oxylabs Proxy Setup for Binance Monitor on Vercel
+
+## Overview
+
+This document describes the proxy configuration used to bypass Binance API geographic restrictions when running on Vercel's cloud infrastructure.
+
+## Problem Statement
+
+Binance blocks API requests from major cloud provider IP ranges (AWS, GCP, Azure, Vercel) as part of their geographic restriction policy. This affects:
+- ❌ Private API endpoints (account data, NAV, balances, transactions)
+- ✅ Public data endpoints can use `data-api.binance.vision` (prices work without proxy)
+
+## Solution Architecture
+
+We use Oxylabs proxy service to route Binance API requests through residential IPs that are not blocked:
+
+```
+Vercel Function → Oxylabs Proxy → Binance API → Response
+```
+
+## Configuration
+
+### 1. Environment Variable
+
+Set the following environment variable on Vercel:
+
+```bash
+OXYLABS_PROXY_URL=https://customer-USERNAME:PASSWORD@cz-pr.oxylabs.io:18001
+```
+
+**Important**: Replace `USERNAME` and `PASSWORD` with your actual Oxylabs credentials.
+
+### 2. Automatic Activation
+
+The proxy activates automatically when:
+- Running on Vercel (detected via `VERCEL` or `VERCEL_ENV` environment variables)
+- `OXYLABS_PROXY_URL` environment variable is configured
+- Making authenticated API calls (not needed for price fetching)
+
+### 3. Configuration in settings.json
+
+```json
+"proxy": {
+    "enabled_on_vercel": true,
+    "url_env": "OXYLABS_PROXY_URL",
+    "timeout_seconds": 30,
+    "verify_ssl": true,
+    "description": "Proxy configuration for bypassing Binance geographic restrictions on Vercel"
+}
+```
+
+## Implementation Details
+
+### Proxy Detection Logic
+
+The `ProxyConfig` class in `config/__init__.py` includes smart activation:
+
+```python
+@property
+def is_active(self) -> bool:
+    """Check if proxy should be active (Vercel environment + URL configured)."""
+    is_vercel = bool(os.environ.get('VERCEL') or os.environ.get('VERCEL_ENV'))
+    return self.enabled_on_vercel and is_vercel and bool(self.url)
+```
+
+### Client Creation
+
+The `create_binance_client()` function in `api/index.py` handles proxy application:
+
+```python
+def create_binance_client(api_key='', api_secret='', tld='com', for_prices_only=False):
+    client = BinanceClient(api_key, api_secret, tld=tld)
+    
+    # Price-only clients use data API (no proxy needed)
+    if for_prices_only:
+        client.API_URL = 'https://data-api.binance.vision/api'
+        return client
+    
+    # Apply proxy for authenticated endpoints on Vercel
+    if hasattr(settings, 'proxy') and settings.proxy.is_active:
+        # ... proxy configuration ...
+```
+
+## Usage Patterns
+
+### 1. Price Fetching (No Proxy)
+```python
+# Always uses data-api.binance.vision
+client = create_binance_client(for_prices_only=True)
+prices = client.get_symbol_ticker(symbol='BTCUSDT')
+```
+
+### 2. Account Data (Proxy on Vercel)
+```python
+# Uses proxy on Vercel, direct connection locally
+client = create_binance_client(api_key, api_secret)
+nav = client.futures_account()
+```
+
+### 3. Dashboard (No Proxy)
+The dashboard (`api/dashboard.py`) only reads from Supabase database and never calls Binance API directly, so no proxy is needed.
+
+## Vercel Deployment
+
+1. **Add Environment Variable**:
+   ```bash
+   vercel env add OXYLABS_PROXY_URL
+   # Enter the full proxy URL when prompted
+   ```
+
+2. **Deploy**:
+   ```bash
+   vercel --prod
+   ```
+
+3. **Verify**:
+   - Check system logs for "proxy_enabled" entries
+   - Monitor successful API calls in Supabase logs
+
+## Testing
+
+### Local Testing (No Proxy)
+```bash
+# Run locally - proxy will NOT activate
+python -m api.index
+```
+
+### Vercel Testing (With Proxy)
+```bash
+# Set test environment variable
+export VERCEL=1
+export OXYLABS_PROXY_URL=https://customer-USERNAME:PASSWORD@cz-pr.oxylabs.io:18001
+
+# Run with simulated Vercel environment
+python -m api.index
+```
+
+## Troubleshooting
+
+### 1. Proxy Not Activating
+- Check if `VERCEL` or `VERCEL_ENV` environment variables are set
+- Verify `OXYLABS_PROXY_URL` is properly configured
+- Look for "proxy_enabled" in system logs
+
+### 2. Authentication Errors
+- Verify Oxylabs credentials are correct
+- Check proxy URL format: `https://customer-USERNAME:PASSWORD@HOST:PORT`
+- Ensure no special characters in password need URL encoding
+
+### 3. Connection Timeouts
+- Default timeout is 30 seconds (configurable in settings.json)
+- Oxylabs proxy may add 2-3 seconds latency
+- Consider increasing timeout for large data requests
+
+### 4. SSL Verification
+- Set `verify_ssl: false` in settings.json if SSL issues occur
+- Not recommended for production without investigating root cause
+
+## Security Considerations
+
+1. **Never commit proxy credentials** to version control
+2. **Use environment variables** for all sensitive data
+3. **Monitor proxy usage** to prevent unauthorized access
+4. **Rotate credentials** periodically
+5. **Restrict proxy access** to specific Vercel projects
+
+## Cost Optimization
+
+- Proxy is only used for authenticated endpoints
+- Price fetching uses free data-api.binance.vision
+- Dashboard doesn't use proxy (database only)
+- Hourly cron minimizes proxy usage
+
+## Alternative Solutions
+
+If Oxylabs proxy becomes unavailable:
+
+1. **Other Proxy Services**: Bright Data, SmartProxy, IPRoyal
+2. **VPS Solution**: Deploy on non-cloud VPS with residential IP
+3. **API Gateway**: Use AWS API Gateway in allowed regions
+4. **Binance Cloud**: Use Binance's own cloud services
+
+## References
+
+- [Oxylabs Documentation](https://developers.oxylabs.io/)
+- [Binance API Documentation](https://binance-docs.github.io/apidocs/)
+- [Vercel Environment Variables](https://vercel.com/docs/environment-variables)

--- a/api/test_proxy.py
+++ b/api/test_proxy.py
@@ -1,0 +1,90 @@
+"""
+Test endpoint for proxy configuration on Vercel
+"""
+
+import os
+import json
+from http.server import BaseHTTPRequestHandler
+from api.index import create_binance_client
+from api.logger import get_logger, LogCategory
+from config import settings
+
+class handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        logger = get_logger()
+        
+        # Collect test information
+        test_info = {
+            "environment": {
+                "VERCEL": os.getenv('VERCEL', 'Not set'),
+                "VERCEL_ENV": os.getenv('VERCEL_ENV', 'Not set'),
+                "OXYLABS_PROXY_URL": "Set" if os.getenv('OXYLABS_PROXY_URL') else "Not set",
+            },
+            "proxy_config": {
+                "enabled_on_vercel": getattr(settings.proxy, 'enabled_on_vercel', 'N/A'),
+                "is_active": getattr(settings.proxy, 'is_active', False) if hasattr(settings, 'proxy') else False,
+                "has_url": bool(settings.proxy.url) if hasattr(settings, 'proxy') else False
+            },
+            "tests": {}
+        }
+        
+        # Test 1: Price client (should use data API)
+        try:
+            price_client = create_binance_client(for_prices_only=True)
+            test_info["tests"]["price_client"] = {
+                "success": True,
+                "api_url": price_client.API_URL,
+                "expected": "https://data-api.binance.vision/api",
+                "correct": price_client.API_URL == "https://data-api.binance.vision/api"
+            }
+        except Exception as e:
+            test_info["tests"]["price_client"] = {
+                "success": False,
+                "error": str(e)
+            }
+        
+        # Test 2: Regular client (should use proxy on Vercel)
+        try:
+            regular_client = create_binance_client('test', 'test')
+            test_info["tests"]["regular_client"] = {
+                "success": True,
+                "api_url": regular_client.API_URL,
+                "has_session": hasattr(regular_client, 'session') and regular_client.session is not None,
+                "proxy_applied": hasattr(regular_client.session, 'proxies') if hasattr(regular_client, 'session') else False
+            }
+            
+            # Log proxy status
+            if test_info["proxy_config"]["is_active"]:
+                logger.info(LogCategory.SYSTEM, "proxy_test", 
+                           "Proxy test: Proxy is ACTIVE on Vercel", 
+                           data=test_info)
+            else:
+                logger.info(LogCategory.SYSTEM, "proxy_test", 
+                           "Proxy test: Proxy is NOT active", 
+                           data=test_info)
+                
+        except Exception as e:
+            test_info["tests"]["regular_client"] = {
+                "success": False,
+                "error": str(e)
+            }
+        
+        # Test 3: Try fetching BTC price
+        try:
+            price_client = create_binance_client(for_prices_only=True)
+            ticker = price_client.get_symbol_ticker(symbol='BTCUSDT')
+            test_info["tests"]["price_fetch"] = {
+                "success": True,
+                "btc_price": float(ticker['price'])
+            }
+        except Exception as e:
+            test_info["tests"]["price_fetch"] = {
+                "success": False,
+                "error": str(e)
+            }
+        
+        # Send response
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(test_info, indent=2).encode('utf-8'))

--- a/config/settings.json
+++ b/config/settings.json
@@ -53,6 +53,14 @@
     }
   },
   
+  "proxy": {
+    "enabled_on_vercel": true,
+    "url_env": "OXYLABS_PROXY_URL",
+    "timeout_seconds": 30,
+    "verify_ssl": true,
+    "description": "Proxy configuration for bypassing Binance geographic restrictions on Vercel"
+  },
+  
   "dashboard": {
     "host": "localhost",
     "port": 8000,

--- a/test_proxy.py
+++ b/test_proxy.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Test script for proxy configuration and activation logic
+"""
+
+import os
+import sys
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from config import settings
+from api.index import create_binance_client
+from api.logger import get_logger, LogCategory
+
+def test_proxy_config():
+    """Test proxy configuration loading"""
+    print("\n=== Testing Proxy Configuration ===")
+    
+    if hasattr(settings, 'proxy'):
+        print(f"✅ Proxy config loaded")
+        print(f"  - enabled_on_vercel: {settings.proxy.enabled_on_vercel}")
+        print(f"  - url_env: {settings.proxy.url_env}")
+        print(f"  - timeout_seconds: {settings.proxy.timeout_seconds}")
+        print(f"  - verify_ssl: {settings.proxy.verify_ssl}")
+        
+        # Check proxy URL
+        proxy_url = settings.proxy.url
+        if proxy_url:
+            # Hide credentials in output
+            if '@' in proxy_url:
+                parts = proxy_url.split('@')
+                safe_url = parts[0].split('//')[0] + '//*****:*****@' + parts[1]
+            else:
+                safe_url = proxy_url
+            print(f"  - proxy URL: {safe_url}")
+        else:
+            print(f"  - proxy URL: Not set (env var {settings.proxy.url_env} missing)")
+        
+        # Check activation
+        print(f"\n  - is_active: {settings.proxy.is_active}")
+        print(f"  - VERCEL env: {os.getenv('VERCEL', 'Not set')}")
+        print(f"  - VERCEL_ENV env: {os.getenv('VERCEL_ENV', 'Not set')}")
+    else:
+        print("❌ Proxy config not found in settings")
+
+def test_client_creation():
+    """Test Binance client creation with different scenarios"""
+    print("\n\n=== Testing Client Creation ===")
+    
+    # Test 1: Price-only client (should use data API)
+    print("\n1. Price-only client:")
+    client = create_binance_client(for_prices_only=True)
+    print(f"  - API URL: {client.API_URL}")
+    print(f"  - Expected: https://data-api.binance.vision/api")
+    print(f"  - ✅ Correct" if client.API_URL == 'https://data-api.binance.vision/api' else "  - ❌ Incorrect")
+    
+    # Test 2: Regular client without Vercel env
+    print("\n2. Regular client (no Vercel env):")
+    client = create_binance_client('test_key', 'test_secret')
+    print(f"  - API URL: {client.API_URL}")
+    print(f"  - Has session: {hasattr(client, 'session') and client.session is not None}")
+    print(f"  - Expected: No proxy session")
+    
+    # Test 3: Regular client with simulated Vercel env
+    print("\n3. Regular client (simulated Vercel):")
+    original_vercel = os.getenv('VERCEL')
+    try:
+        os.environ['VERCEL'] = '1'
+        # Reload settings to pick up env change
+        from config import get_settings
+        test_settings = get_settings(force_reload=True)
+        
+        if hasattr(test_settings, 'proxy'):
+            print(f"  - Proxy is_active: {test_settings.proxy.is_active}")
+        
+        # Note: Can't fully test without actual proxy URL in env
+        print("  - (Full test requires OXYLABS_PROXY_URL env var)")
+    finally:
+        if original_vercel:
+            os.environ['VERCEL'] = original_vercel
+        else:
+            os.environ.pop('VERCEL', None)
+
+def test_price_fetch():
+    """Test fetching prices using data API"""
+    print("\n\n=== Testing Price Fetch ===")
+    
+    try:
+        client = create_binance_client(for_prices_only=True)
+        
+        # Test BTC price
+        btc_ticker = client.get_symbol_ticker(symbol='BTCUSDT')
+        btc_price = float(btc_ticker['price'])
+        print(f"✅ BTC price fetched: ${btc_price:,.2f}")
+        
+        # Test ETH price
+        eth_ticker = client.get_symbol_ticker(symbol='ETHUSDT')
+        eth_price = float(eth_ticker['price'])
+        print(f"✅ ETH price fetched: ${eth_price:,.2f}")
+        
+        print("\nData API working correctly!")
+        
+    except Exception as e:
+        print(f"❌ Error fetching prices: {e}")
+
+if __name__ == "__main__":
+    print("=" * 50)
+    print("Binance Monitor - Proxy Configuration Test")
+    print("=" * 50)
+    
+    test_proxy_config()
+    test_client_creation()
+    test_price_fetch()
+    
+    print("\n" + "=" * 50)
+    print("Test completed!")
+    print("=" * 50)


### PR DESCRIPTION
## Summary
This PR adds Oxylabs proxy support to bypass Binance geographic restrictions on Vercel.

## Problem
- Binance blocks all cloud provider IPs (AWS, GCP, Vercel)
- Data API works for prices, but private endpoints (NAV, balances) were blocked
- Even Frankfurt region deployment didn't help

## Solution
- Conditional proxy usage only on Vercel deployments
- Proxy applies only to authenticated API calls
- Price fetching continues using data-api.binance.vision
- Dashboard remains proxy-independent

## Changes
- Added proxy configuration to `settings.json`
- Created `ProxyConfig` class with smart activation
- Implemented `create_binance_client()` wrapper function
- Added comprehensive documentation

## Testing
- Local development: No proxy (unchanged behavior)
- Vercel: Proxy activates automatically when configured
- Test endpoint available at `/api/test_proxy`

## Configuration Required
Set environment variable on Vercel:
```
OXYLABS_PROXY_URL=https://customer-USERNAME:PASSWORD@cz-pr.oxylabs.io:18001
```

## Security
- Proxy credentials only in environment variables
- No hardcoded values in code
- Proxy active only when: VERCEL env detected + OXYLABS_PROXY_URL configured